### PR TITLE
fix(wip): dropdownmenu onclick은 requestAnimationFrame으로 감싸서 dropdownm…

### DIFF
--- a/apps/frontend/components/ui/dropdown-menu.tsx
+++ b/apps/frontend/components/ui/dropdown-menu.tsx
@@ -63,6 +63,7 @@ function DropdownMenuItem({
   className,
   inset,
   variant = 'default',
+  onClick,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
   inset?: boolean;
@@ -73,6 +74,11 @@ function DropdownMenuItem({
       data-slot="dropdown-menu-item"
       data-inset={inset}
       data-variant={variant}
+      onClick={(e) => {
+        requestAnimationFrame(() => {
+          onClick?.(e);
+        });
+      }}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex  items-center gap-2 rounded-sm !px-2 !py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:!pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 cursor-pointer",
         className


### PR DESCRIPTION
fix(wip): dropdownmenu onclick은 requestAnimationFrame으로 감싸서 dropdownmenu가 닫힌 후 실행되도록 하기. react synthtic event의 꼬임 방지

참고자료: https://github.com/radix-ui/primitives/issues/1891

